### PR TITLE
Bug Fix: Minute interval input fails to update in UI

### DIFF
--- a/projects/swimlane/ngx-cron/src/lib/ngx-cron.service.ts
+++ b/projects/swimlane/ngx-cron/src/lib/ngx-cron.service.ts
@@ -361,8 +361,8 @@ export class NgxCronService {
   }
 
   private getSegment(value: string): Array<Array<string | number>> {
-    if (value === undefined) {
-      value = '*';
+    if (value === undefined || value === '*') {
+      return [['*', 1]];
     }
     return value.split(',').map(s => {
       if (s === undefined) {


### PR DESCRIPTION
## Summary

- Fix: The minute interval input now updates in the UI as expected when switching between cron component instances where one instance is set to a 1 minute interval and another is set to a different interval. See video demo for example.

https://github.com/user-attachments/assets/2ebf0e78-5ed1-48de-b128-5aaf90fd38aa
 

## Checklist

- [x] \*Added a code reviewer
- [ ] Added unit tests
- [ ] Added changes to `/projects/swimlane/ngx-cron/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
