### PR TITLE
fix: Alignment in the input fields

### DIFF
--- a/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.html
+++ b/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.html
@@ -1,6 +1,6 @@
 <div>
   @if (_allowedPeriods.length > 1) {
-    <div>
+    <div class="period-selection">
       @for (key of _allowedPeriods; track key) {
         <ngx-button
           class="btn"
@@ -23,8 +23,7 @@
         </span>
       }
       @if (cronData.period === 'Hourly') {
-        <span>
-          At
+          <span>At</span>
           <ngx-input
             type="number"
             [(ngModel)]="cronData.minute"
@@ -33,19 +32,18 @@
             min="0"
             max="59"
             [disabled]="disabled"
+            [withHint]="false"
             >
           </ngx-input>
           <span [ngPlural]="cronData.minute">
             <ng-template ngPluralCase="=1">minute</ng-template>
             <ng-template ngPluralCase="other">minutes</ng-template>
           </span>
-          past the hour
-        </span>
+          <span>past the hour</span>
       }
 
       @if (cronData.period === 'Secondly') {
-        <span class="every">
-          Every
+          <span>Every</span>
           <ngx-input
             type="number"
             [ngModel]="cronData.secondInterval"
@@ -54,17 +52,16 @@
             min="1"
             max="59"
             [disabled]="disabled"
+            [withHint]="false"
             >
           </ngx-input>
           <span [ngPlural]="cronData.secondInterval">
             <ng-template ngPluralCase="=1">second</ng-template>
             <ng-template ngPluralCase="other">seconds</ng-template>
           </span>
-        </span>
       }
       @if (cronData.period === 'Minutely') {
-        <span class="every">
-          Every
+          <span>Every</span>
           <ngx-input
             type="number"
             [ngModel]="cronData.minuteInterval"
@@ -73,13 +70,13 @@
             min="1"
             max="59"
             [disabled]="disabled"
+            [withHint]="false"
             >
           </ngx-input>
           <span [ngPlural]="cronData.minuteInterval">
             <ng-template ngPluralCase="=1">minute</ng-template>
             <ng-template ngPluralCase="other">minutes</ng-template>
           </span>
-        </span>
       }
       @if (
         cronData.period === 'Daily' ||
@@ -87,9 +84,7 @@
         cronData.period === 'Monthly' ||
         cronData.period === 'Yearly'
         ) {
-        <span
-          >
-          At
+          <span>At</span>
           <ngx-date-time
             [ngModel]="time"
             (ngModelChange)="onValueChange($event)"
@@ -102,11 +97,9 @@
             (dateTimeSelected)="onDateTimeSelected($event)"
             >
           </ngx-date-time>
-        </span>
       }
       @if (cronData.period === 'Monthly' || cronData.period === 'Yearly') {
-        <span
-          >, on day
+          <span>, on day</span>
           <ngx-input
             type="number"
             [(ngModel)]="cronData.day"
@@ -114,14 +107,14 @@
             min="1"
             [max]="cronData.period === 'Yearly' ? cronData.daysMax : 31"
             [disabled]="disabled"
+            [withHint]="false"
             >
           </ngx-input>
-          of the month
-        </span>
+          <span>of the month</span>
       }
       @if (cronData.period === 'Yearly') {
         <span
-          >, only in
+          >, only in</span>
           <ngx-select
             class="ngx-scroll"
             [filterable]="false"
@@ -135,11 +128,10 @@
               <ngx-select-option [name]="month" [value]="month"></ngx-select-option>
             }
           </ngx-select>
-        </span>
       }
       @if (cronData.period === 'Weekly') {
         <span>
-          , only on
+          , only on</span>
           <ngx-select
             [filterable]="false"
             [forceDownwardOpening]="true"
@@ -152,7 +144,6 @@
               <ngx-select-option [name]="day" [value]="day"></ngx-select-option>
             }
           </ngx-select>
-        </span>
       }
     </div>
     @if (!cronData.valid && cronData.period !== 'Custom') {

--- a/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.html
+++ b/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.html
@@ -1,164 +1,147 @@
 <div>
   @if (_allowedPeriods.length > 1) {
-    <div class="period-selection">
-      @for (key of _allowedPeriods; track key) {
-        <ngx-button
-          class="btn"
-          [class.btn-primary]="cronData.period === key"
-          (click)="cronData.period = key; cronDataChanged()"
-          [disabled]="disabled"
-          >
-          {{ key }}
-        </ngx-button>
-      }
-    </div>
+  <div class="period-selection">
+    @for (key of _allowedPeriods; track key) {
+    <ngx-button
+      class="btn"
+      [class.btn-primary]="cronData.period === key"
+      (click)="cronData.period = key; cronDataChanged()"
+      [disabled]="disabled"
+    >
+      {{ key }}
+    </ngx-button>
+    }
+  </div>
   }
 
   <div class="selections">
     <div class="date-selection">
       @if (cronData.period === 'Custom') {
-        <span>
-          <ngx-input [(ngModel)]="cron" [hint]="cronData.description" [disabled]="disabled || disableCustomInput">
-          </ngx-input>
-        </span>
-      }
-      @if (cronData.period === 'Hourly') {
-          <span>At</span>
-          <ngx-input
-            type="number"
-            [(ngModel)]="cronData.minute"
-            (ngModelChange)="cronData.minute = +$event"
-            (change)="cronDataChanged()"
-            min="0"
-            max="59"
-            [disabled]="disabled"
-            [withHint]="false"
-            >
-          </ngx-input>
-          <span [ngPlural]="cronData.minute">
-            <ng-template ngPluralCase="=1">minute</ng-template>
-            <ng-template ngPluralCase="other">minutes</ng-template>
-          </span>
-          <span>past the hour</span>
-      }
-
-      @if (cronData.period === 'Secondly') {
-          <span>Every</span>
-          <ngx-input
-            type="number"
-            [ngModel]="cronData.secondInterval"
-            (ngModelChange)="cronData.secondInterval = +$event"
-            (change)="cronDataChanged()"
-            min="1"
-            max="59"
-            [disabled]="disabled"
-            [withHint]="false"
-            >
-          </ngx-input>
-          <span [ngPlural]="cronData.secondInterval">
-            <ng-template ngPluralCase="=1">second</ng-template>
-            <ng-template ngPluralCase="other">seconds</ng-template>
-          </span>
-      }
-      @if (cronData.period === 'Minutely') {
-          <span>Every</span>
-          <ngx-input
-            type="number"
-            [ngModel]="cronData.minuteInterval"
-            (ngModelChange)="cronData.minuteInterval = +$event"
-            (change)="cronDataChanged()"
-            min="1"
-            max="59"
-            [disabled]="disabled"
-            [withHint]="false"
-            >
-          </ngx-input>
-          <span [ngPlural]="cronData.minuteInterval">
-            <ng-template ngPluralCase="=1">minute</ng-template>
-            <ng-template ngPluralCase="other">minutes</ng-template>
-          </span>
-      }
-      @if (
-        cronData.period === 'Daily' ||
-        cronData.period === 'Weekly' ||
-        cronData.period === 'Monthly' ||
-        cronData.period === 'Yearly'
-        ) {
-          <span>At</span>
-          <ngx-date-time
-            [ngModel]="time"
-            (ngModelChange)="onValueChange($event)"
-            inputType="time"
-            [displayMode]="disableTimezoneDisplay ? 'local' : undefined"
-            [disabled]="disabled"
-            [timezone]="timezone"
-            [autosize]="true"
-            (blur)="onBlurDateTimeChanged($event)"
-            (dateTimeSelected)="onDateTimeSelected($event)"
-            >
-          </ngx-date-time>
-      }
-      @if (cronData.period === 'Monthly' || cronData.period === 'Yearly') {
-          <span>, on day</span>
-          <ngx-input
-            type="number"
-            [(ngModel)]="cronData.day"
-            (change)="cronDataChanged()"
-            min="1"
-            [max]="cronData.period === 'Yearly' ? cronData.daysMax : 31"
-            [disabled]="disabled"
-            [withHint]="false"
-            >
-          </ngx-input>
-          <span>of the month</span>
-      }
-      @if (cronData.period === 'Yearly') {
-        <span
-          >, only in</span>
-          <ngx-select
-            class="ngx-scroll"
-            [filterable]="false"
-            [forceDownwardOpening]="true"
-            [ngModel]="[cronData.month]"
-            [disabled]="disabled"
-            (change)="cronData.month = $event[0]; cronDataChanged()"
-            [allowClear]="false"
-            >
-            @for (month of months; track month) {
-              <ngx-select-option [name]="month" [value]="month"></ngx-select-option>
-            }
-          </ngx-select>
-      }
-      @if (cronData.period === 'Weekly') {
-        <span>
-          , only on</span>
-          <ngx-select
-            [filterable]="false"
-            [forceDownwardOpening]="true"
-            [ngModel]="[cronData.weekday]"
-            (change)="cronData.weekday = $event[0]; cronDataChanged()"
-            [allowClear]="false"
-            [disabled]="disabled"
-            >
-            @for (day of dows; track day) {
-              <ngx-select-option [name]="day" [value]="day"></ngx-select-option>
-            }
-          </ngx-select>
+      <span>
+        <ngx-input [(ngModel)]="cron" [hint]="cronData.description" [disabled]="disabled || disableCustomInput">
+        </ngx-input>
+      </span>
+      } @if (cronData.period === 'Hourly') {
+      <span class="cron-input__text">At</span>
+      <ngx-input
+        type="number"
+        [(ngModel)]="cronData.minute"
+        (ngModelChange)="cronData.minute = +$event"
+        (change)="cronDataChanged()"
+        min="0"
+        max="59"
+        [disabled]="disabled"
+        [withHint]="false"
+      >
+      </ngx-input>
+      <span class="cron-input__text" [ngPlural]="cronData.minute">
+        <ng-template ngPluralCase="=1">minute</ng-template>
+        <ng-template ngPluralCase="other">minutes</ng-template>
+      </span>
+      <span class="cron-input__text">past the hour</span>
+      } @if (cronData.period === 'Secondly') {
+      <span class="cron-input__text">Every</span>
+      <ngx-input
+        type="number"
+        [ngModel]="cronData.secondInterval"
+        (ngModelChange)="cronData.secondInterval = +$event"
+        (change)="cronDataChanged()"
+        min="1"
+        max="59"
+        [disabled]="disabled"
+        [withHint]="false"
+      >
+      </ngx-input>
+      <span class="cron-input__text" [ngPlural]="cronData.secondInterval">
+        <ng-template ngPluralCase="=1">second</ng-template>
+        <ng-template ngPluralCase="other">seconds</ng-template>
+      </span>
+      } @if (cronData.period === 'Minutely') {
+      <span class="cron-input__text">Every</span>
+      <ngx-input
+        type="number"
+        [ngModel]="cronData.minuteInterval"
+        (ngModelChange)="cronData.minuteInterval = +$event"
+        (change)="cronDataChanged()"
+        min="1"
+        max="59"
+        [disabled]="disabled"
+        [withHint]="false"
+      >
+      </ngx-input>
+      <span class="cron-input__text" [ngPlural]="cronData.minuteInterval">
+        <ng-template ngPluralCase="=1">minute</ng-template>
+        <ng-template ngPluralCase="other">minutes</ng-template>
+      </span>
+      } @if ( cronData.period === 'Daily' || cronData.period === 'Weekly' || cronData.period === 'Monthly' ||
+      cronData.period === 'Yearly' ) {
+      <span class="cron-input__text">At</span>
+      <ngx-date-time
+        [ngModel]="time"
+        (ngModelChange)="onValueChange($event)"
+        inputType="time"
+        [displayMode]="disableTimezoneDisplay ? 'local' : undefined"
+        [disabled]="disabled"
+        [timezone]="timezone"
+        [autosize]="true"
+        (blur)="onBlurDateTimeChanged($event)"
+        (dateTimeSelected)="onDateTimeSelected($event)"
+      >
+      </ngx-date-time>
+      } @if (cronData.period === 'Monthly' || cronData.period === 'Yearly') {
+      <span class="cron-input__text">, on day</span>
+      <ngx-input
+        type="number"
+        [(ngModel)]="cronData.day"
+        (change)="cronDataChanged()"
+        min="1"
+        [max]="cronData.period === 'Yearly' ? cronData.daysMax : 31"
+        [disabled]="disabled"
+        [withHint]="false"
+      >
+      </ngx-input>
+      <span class="cron-input__text">of the month</span>
+      } @if (cronData.period === 'Yearly') {
+      <span class="cron-input__text">, only in</span>
+      <ngx-select
+        class="ngx-scroll"
+        [filterable]="false"
+        [forceDownwardOpening]="true"
+        [ngModel]="[cronData.month]"
+        [disabled]="disabled"
+        (change)="cronData.month = $event[0]; cronDataChanged()"
+        [allowClear]="false"
+        [withHint]="false"
+      >
+        @for (month of months; track month) {
+        <ngx-select-option [name]="month" [value]="month"></ngx-select-option>
+        }
+      </ngx-select>
+      } @if (cronData.period === 'Weekly') {
+      <span class="cron-input__text">, only on</span>
+      <ngx-select
+        [filterable]="false"
+        [forceDownwardOpening]="true"
+        [ngModel]="[cronData.weekday]"
+        (change)="cronData.weekday = $event[0]; cronDataChanged()"
+        [allowClear]="false"
+        [disabled]="disabled"
+        [withHint]="false"
+      >
+        @for (day of dows; track day) {
+        <ngx-select-option [name]="day" [value]="day"></ngx-select-option>
+        }
+      </ngx-select>
       }
     </div>
     @if (!cronData.valid && cronData.period !== 'Custom') {
-      <p class="invalid-expression">
-        {{ cronData.description }}
-      </p>
-    }
-
-    @if (language !== 'en' && cronData.valid && cronData.period !== 'Custom') {
-      <p
-        class="language-expression"
-        [ngClass]="{ 'hint-margin-top': cronData.period === 'Daily' }"
-        >
-        {{ cronData.description }}
-      </p>
+    <p class="invalid-expression">
+      {{ cronData.description }}
+    </p>
+    } @if (language !== 'en' && cronData.valid && cronData.period !== 'Custom') {
+    <p class="language-expression" [ngClass]="{ 'hint-margin-top': cronData.period === 'Daily' }">
+      {{ cronData.description }}
+    </p>
     }
   </div>
 </div>

--- a/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.scss
+++ b/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.scss
@@ -2,6 +2,7 @@ ngx-cron-input {
   display: block;
   border: 1px solid transparent;
   padding: 10px;
+  font-family: Source Sans Pro;
 
   .ngx-input,
   .ngx-select,
@@ -26,23 +27,29 @@ ngx-cron-input {
     min-width: 200px;
   }
 
-  ngx-date-time {
+  ngx-date-time.ngx-date-time.autosize.no-label {
     display: inline-block !important;
     min-width: 90px;
     vertical-align: middle;
     height: 25px;
 
-    .ngx-input {
-      margin-top: 0;
+    > div {
+      position: relative;
 
-      .ngx-input-wrap .ngx-input-hint {
-        height: 0;
-        min-height: 0;
+      .ngx-input {
+        margin-top: 0;
+
+        .ngx-input-wrap .ngx-input-hint {
+          height: 0;
+          min-height: 0;
+        }
       }
-    }
-    .calendar-dialog-btn {
-      font-size: 0.8em;
-      margin-top: -2px;
+      // Style to position button in the middle of the input
+      button.calendar-dialog-btn {
+        margin-top: -4px; // Input has a margin of 8px to position the button in middle we have a margin of -4px to position the button in the middle
+        top: 50%;
+        transform: translateY(-50%);
+      }
     }
   }
 
@@ -62,10 +69,13 @@ ngx-cron-input {
   }
 
   .selections {
-    margin-top: 16px;
-    height: 70px;
+    margin-top: var(--spacing-8);
     display: flex;
     flex-direction: column;
+
+    .cron-input__text {
+      font-size: var(--font-size-s);
+    }
 
     .date-selection {
       display: inline-flex;

--- a/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.scss
+++ b/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.scss
@@ -52,11 +52,15 @@ ngx-cron-input {
 
   .ngx-button {
     padding: 0.35rem;
-    margin-right: 5px;
     font-size: 0.8em;
   }
 
-  .period-selection,
+  .period-selection {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+
   .selections {
     margin-top: 16px;
     height: 70px;
@@ -64,8 +68,10 @@ ngx-cron-input {
     flex-direction: column;
 
     .date-selection {
-      display: inline-block;
+      display: inline-flex;
       align-items: baseline;
+      flex-wrap: wrap;
+      gap: 5px;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixed mis-alignments in the fields in ngx-cron inputs. 
Added all the fields and wording on same level and put them in flex wrap so they are aligned properly.

## Checklist

- [x] \*Added a code reviewer
- [ ] Added unit tests
- [ ] Added changes to `/projects/swimlane/ngx-cron/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

Before: 

https://github.com/user-attachments/assets/778e4cd9-57bd-4a3a-9cc2-faa53e913bcf


After:

https://github.com/user-attachments/assets/692865f7-aa71-427f-a4f9-4be9dd47d94f



_\*required_
