### PR TITLE
Fix: update displayed time when cron input changes programmatically

### DIFF
--- a/projects/swimlane/ngx-cron/CHANGELOG.md
+++ b/projects/swimlane/ngx-cron/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (unreleased)
 
-- Bug Fix: Update time when cron value changed 
+- Bug Fix: Update time when cron value changed
 
 ## 7.0.0
 

--- a/projects/swimlane/ngx-cron/CHANGELOG.md
+++ b/projects/swimlane/ngx-cron/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Bug Fix: Update time when cron value changed 
+
 ## 7.0.0
 
 - Enhancement: Added support for Angular 21

--- a/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.spec.ts
+++ b/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.spec.ts
@@ -132,4 +132,15 @@ describe('NgxCronComponent', () => {
     expect(selections.textContent).toContain('on day');
     expect(selections.textContent).toContain('of the month');
   });
+
+  it('should update the displayed time when the cron input changes', () => {
+    fixture.componentRef.setInput('cron', '0 6 * * *');
+    fixture.detectChanges();
+    expect(component.time).toBe('6:00 AM');
+
+    fixture.componentRef.setInput('cron', '0 7 * * *');
+    fixture.detectChanges();
+    expect(component.time).toBe('7:00 AM');
+    expect(component.description).toBe('At 07:00 AM');
+  });
 });

--- a/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.ts
+++ b/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.ts
@@ -143,6 +143,10 @@ export class NgxCronComponent implements OnChanges, OnInit {
 
       this.disableCustomInput = this._allowedPeriods.indexOf(Period.Custom) < 0;
     }
+
+    if ('cron' in changes && this.cronData.time) {
+      this.time = this.cronData.time.format(this.timeFormat);
+    }
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary

When the cron @Input is updated from outside the component (e.g. binding to a parent value, switching between instances, or resetting the form), the internal cronData.time is refreshed via setCron, but the time display string bound to the time picker is not. The UI can keep showing a stale time (e.g. 12:00 AM) even though the cron expression reflects a different hour (e.g. 0 7 * * *).

This change syncs the displayed time in ngOnChanges whenever cron changes, matching the behavior already applied in ngOnInit and cronDataChanged

## Checklist

- [X] \*Added a code reviewer
- [X] Added unit tests
- [ ] Added changes to `/projects/swimlane/ngx-cron/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-sync fix in the cron component with no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a bug where **programmatic updates** to the `cron` `@Input` refreshed internal `cronData` but left the **time picker label** (`component.time`) stale.
> 
> `ngOnChanges` now reformats `this.time` from `cronData.time` whenever `cron` changes, aligning with `ngOnInit` and `cronDataChanged`. A unit test covers `setInput('cron', …)` transitions (e.g. 6:00 AM → 7:00 AM). CHANGELOG HEAD notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17bad4ec92a8244730f7c7f18d74905d2350514f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->