### PR TITLE
fix: Infinite onchange loop

### DIFF
--- a/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.ts
+++ b/projects/swimlane/ngx-cron/src/lib/ngx-cron.component.ts
@@ -12,7 +12,7 @@ import {
 
 import moment from 'moment-timezone';
 
-import { NgxCronService, ICronData, Period, Weekday, Month } from './ngx-cron.service';
+import { NgxCronService, ICronData, Period } from './ngx-cron.service';
 
 @Component({
   selector: 'ngx-cron-input',
@@ -89,7 +89,7 @@ export class NgxCronComponent implements OnChanges, OnInit {
   disableCustomInput = false;
 
   cronData: ICronData;
-  time: string = '12:00 AM';
+  time = '12:00 AM';
 
   private _cron = '0 * * * *';
   private _disabled = false;

--- a/projects/swimlane/ngx-cron/src/lib/ngx-cron.service.ts
+++ b/projects/swimlane/ngx-cron/src/lib/ngx-cron.service.ts
@@ -54,7 +54,7 @@ export interface ICronData {
   day?: number;
   month?: keyof typeof Month;
   daysMax?: number;
-  time?: moment.Moment;
+  time?: moment.Moment | null;
   weekday?: keyof typeof Weekday;
 }
 
@@ -136,7 +136,8 @@ export class NgxCronService {
   private timezone = '';
 
   getMidnight() {
-    return moment.tz([1990, 0, 1, 0, 0, 0], this.timezone);
+    const now = moment.tz(this.timezone);
+    return moment.tz([now.year(), now.month(), now.date(), 0, 0, 0], this.timezone);
   }
 
   toString(cron: string) {
@@ -167,7 +168,7 @@ export class NgxCronService {
         valid: true,
         isQuartz: e.expressionParts[0] !== ''
       };
-    } catch (err) {
+    } catch {
       return {
         description:
           this.validateCronExpression(cron, false, configOverrides)?.error ||
@@ -337,11 +338,14 @@ export class NgxCronService {
     return typeof v === 'number' ? v : null;
   }
 
-  private getTime(expressionParts: string[]): moment.Moment {
+  private getTime(expressionParts: string[]): moment.Moment | null {
     const s = this.getSeconds(expressionParts);
     const h = this.getHour(expressionParts);
     const m = this.getMin(expressionParts);
-    return typeof h === 'number' && typeof m === 'number' ? moment.tz([1990, 1, 1, h, m, s || 0], this.timezone) : null;
+    const now = moment.tz(this.timezone);
+    return typeof h === 'number' && typeof m === 'number'
+      ? moment.tz([now.year(), now.month(), now.date(), h, m, s || 0], this.timezone)
+      : null;
   }
 
   private getMonth(expressionParts: string[]): keyof typeof Month {


### PR DESCRIPTION
## Summary

Issue: 
In few functions (getMidnight/getTime ) we were calculating the offset and time based on hardcoded 1990 anchor date. In few functions we calculated the time using `moment.tz(value, ['h:mm A', 'h:mm A Z'], this.timezone)` which considered today's offset.

In timezones such as America/Chicago, America/Argentina/Buenos_Aires the the offset proved by 1990 winter differed from today's offset hence we had a mismatch in the values provided the functions, this created an infinite loop of changes where value in one function triggered a change in another function and vice-versa.

Fix:
Build the time moment in getMidnight/getTime using the current date instead of the fixed 1990 date, so the offsets matched and same time was produced by both functions and loop is broken.

Also fixed few lint errors.

Before:
https://github.com/user-attachments/assets/0c5ea764-e0ac-4c2f-bfbd-61580d2785af

After:
https://github.com/user-attachments/assets/b3cef650-3077-4c41-a413-1d071cdf0368


## Checklist

- [x] \*Added a code reviewer
- [ ] Added unit tests
- [ ] Added changes to `/projects/swimlane/ngx-cron/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
